### PR TITLE
Unify error format for parsing errors

### DIFF
--- a/src/types/__tests__/validator.test.js
+++ b/src/types/__tests__/validator.test.js
@@ -40,9 +40,11 @@ describe('Validator', () => {
     expect(results).to.have.lengthOf(1);
     expect(results[0]).to.deep.include({
       dataFormat: 'jsonld',
-      message: 'JSON-LD object missing @type attribute',
+      issueMessage: 'JSON-LD object missing @type attribute',
       location: '0,2',
       source: '{}',
+      rootType: 'jsonld',
+      severity: 'ERROR',
     });
   });
 });

--- a/src/validator.js
+++ b/src/validator.js
@@ -196,7 +196,9 @@ export class Validator {
     for (const error of errors) {
       const result = {
         dataFormat: error.format,
-        message: error.message,
+        issueMessage: error.message,
+        rootType: error.format,
+        severity: 'ERROR',
       };
       if (error.sourceCodeLocation) {
         result.location = `${error.sourceCodeLocation.startOffset},${error.sourceCodeLocation.endOffset}`;


### PR DESCRIPTION
## Description

* General parsing errors had a format inconsistent with other errors returned by the validator.
* This PR unifies the error format.

## How Has This Been Tested?

* Updated unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
