### PR TITLE
fix: Reduce requirements for nested ImageObject

### DIFF
--- a/gallery/ImageObject/nested.json
+++ b/gallery/ImageObject/nested.json
@@ -1,0 +1,15 @@
+{
+  "@type": "Organization",
+  "@id": "https://www.example.com/",
+  "name": "Washington Times",
+  "logo": {
+    "@type": "ImageObject",
+    "@id": "https://www.example.com/logo.png",
+    "contentUrl": "https://www.example.com/logo.png"
+  },
+  "image": {
+    "@type": "ImageObject",
+    "@id": "https://www.example.com/logo.png",
+    "contentUrl": "https://www.example.com/logo.png"
+  }
+}

--- a/gallery/Organization/multi-type.json
+++ b/gallery/Organization/multi-type.json
@@ -1,0 +1,5 @@
+{
+  "@type": ["Person", "Organization"],
+  "@id": "https://www.example.com/",
+  "name": "Washington Times"
+}

--- a/src/types/ImageObject.js
+++ b/src/types/ImageObject.js
@@ -13,21 +13,27 @@ import BaseValidator from './base.js';
 
 export default class ImageObjectValidator extends BaseValidator {
   getConditions() {
-    return [
+    const conditions = [
       this.or(this.required('contentUrl', 'url'), this.required('url', 'url')),
+    ];
 
-      this.or(
-        this.required('creator'),
-        this.required('creditText'),
-        this.required('copyrightNotice'),
-        this.required('license'),
-      ),
+    // Only require these additional fields for root image objects
+    if (this.path.length === 1) {
+      conditions.push(
+        this.or(
+          this.required('creator'),
+          this.required('creditText'),
+          this.required('copyrightNotice'),
+          this.required('license'),
+        ),
 
-      this.recommended('acquireLicensePage', 'url'),
-      this.recommended('creator'),
-      this.recommended('creditText'),
-      this.recommended('copyrightNotice'),
-      this.recommended('license'),
-    ].map((c) => c.bind(this));
+        this.recommended('acquireLicensePage', 'url'),
+        this.recommended('creator'),
+        this.recommended('creditText'),
+        this.recommended('copyrightNotice'),
+        this.recommended('license'),
+      );
+    }
+    return conditions.map((c) => c.bind(this));
   }
 }

--- a/src/types/__tests__/ImageObject.test.js
+++ b/src/types/__tests__/ImageObject.test.js
@@ -34,5 +34,11 @@ describe('ImageObjectValidator', () => {
       const issues = await validator.validate(data);
       expect(issues).to.have.lengthOf(2);
     });
+
+    it('should ignore additional fields on nested image objects', async () => {
+      const data = await loadTestData('ImageObject/nested.json', 'jsonld');
+      const issues = await validator.validate(data);
+      expect(issues).to.have.lengthOf(0);
+    });
   });
 });

--- a/src/types/__tests__/Organization.test.js
+++ b/src/types/__tests__/Organization.test.js
@@ -40,5 +40,11 @@ describe('OrganizationValidator', () => {
         severity: 'ERROR',
       });
     });
+
+    it('should validate an organization with multiple types', async () => {
+      const data = await loadTestData('Organization/multi-type.json', 'jsonld');
+      const issues = await validator.validate(data);
+      expect(issues).to.have.lengthOf(0);
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Lower requirements for `ImageObject` which is nested within other entities. e.g. the image of an `Author`. This is in line with the rich results validator, but inconsistent with the documentation.
* Added a test case for entities with multiple types. This is related to https://github.com/herzog31/web-auto-extractor/pull/2

## How Has This Been Tested?

* Added unit tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
