### PR TITLE
fix: Adjust breadcrumb position logic

### DIFF
--- a/gallery/Breadcrumb/valid-text-position.json
+++ b/gallery/Breadcrumb/valid-text-position.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Books",
+      "item": "https://example.com/books"
+    },
+    {
+      "@type": "ListItem",
+      "position": "current page",
+      "name": "Award Winners"
+    }
+  ]
+}

--- a/src/types/__tests__/BreadcrumbList.test.js
+++ b/src/types/__tests__/BreadcrumbList.test.js
@@ -54,6 +54,32 @@ describe('BreadcrumbListValidator', () => {
       });
     });
 
+    it('should validate positions that use text', async () => {
+      const data = await loadTestData(
+        'Breadcrumb/valid-text-position.json',
+        'jsonld',
+      );
+      const issues = await validator.validate(data);
+      expect(issues).to.have.lengthOf(1);
+      expect(issues[0]).to.deep.include({
+        rootType: 'BreadcrumbList',
+        issueMessage: 'Field "item" with URL is missing',
+        severity: 'WARNING',
+        path: [
+          {
+            type: 'BreadcrumbList',
+            index: 0,
+          },
+          {
+            index: 1,
+            length: 2,
+            property: 'itemListElement',
+            type: 'ListItem',
+          },
+        ],
+      });
+    });
+
     it('should detect missing required attributes in invalid1.json', async () => {
       const data = await loadTestData('Breadcrumb/invalid1.json', 'jsonld');
       const issues = await validator.validate(data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* This PR allows the `position` of an item in `BreadcrumbList` to be a non-numeric string to be compliant with https://schema.org/position.
* This change required the logic to determine the last item in the list to change:
    * Determining the last item in the list is only possible, if all position values are either numbers or strings that can be parsed as number. The last item is not required to have an `item` attribute.
    * If just a single position value is a string, no last element can be determined and every list item is required to have an `item` attribute with a valid URL.
    * This behaviour is consistent with the Google Rich Results validator.

## How Has This Been Tested?

* Added new unit test and verified existing tests still pass.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
